### PR TITLE
Check state, not error, when waiting on M35FD

### DIFF
--- a/src/bbos.asm
+++ b/src/bbos.asm
@@ -349,8 +349,9 @@ irq_handler:
     SET A, 0
     SET PUSH, B
         HWI [B]
+    SET A, B
     SET B, POP
-    IFE C, 1
+    IFE A, 3
         SET PC, .drive_irq_wait
     SET [Z+0], 0
     IFE C, 0


### PR DESCRIPTION
The M35FD is specced to return its state in B and error in C when
polled for status. Previously, the code to wait on the drive would
with until the drive didn't show an error of ERROR_BUSY.
Unfortunately, it's not really stated in the spec that the drive
will have ERROR_BUSY while it's busy writing. The emulator I'm
using, DCPUToolchain's, only gives ERROR_BUSY when you try to
initiate a _new_ operation while an existing one is ongoing. It
looks like the spec-correct way to wait on the drive is to wait
for the state code (returned in B) to stop being STATE_BUSY.

This commit does that. With this change, BBOS can boot up from a
floppy image in the current directory at "m35fd.bin" when running
in DCPUToolchain's dtemu.
