### PR TITLE
Don't let WRITE_CHAR write outside VRAM

### DIFF
--- a/src/video.asm
+++ b/src/video.asm
@@ -49,7 +49,7 @@ video_irq:
         BOR [Z+1], 0xF000
     SET [A], [Z+1]
     IFE [Z+0], 1
-        IFL [vram_cursor], vram_edit-vram_end-1
+        IFL [vram_cursor], vram_end-vram_edit-1
             ADD [vram_cursor], 1
     SET PC, .updatescreen
 


### PR DESCRIPTION
This subtraction was backwards, leading to the cursor advancing out of VRAM with lots of calls to writechar(char, 1).

Should writechar ever scroll the screen?

It seems like the behavior you would want would be that you can write characters right up to the end of VRAM, and then on the next writechar call, if vram is full, it would scroll the screen. However, to implement this, it seems like a provision would need to be made for the cursor to be able to be past the end of the screen (to denote that the next character to be printed would require scrolling before printing). If the cursor was at the last position on the screen, the character would just be printed in the bottom right corner.
